### PR TITLE
Update to the latest specs and updated test.asm to use a #include file

### DIFF
--- a/lib.inc
+++ b/lib.inc
@@ -1,0 +1,145 @@
+        ;.ORG 0x8000 ; At 32 Kib ...
+
+        .DD 0xBEBECAFE
+
+; *****************************************************************************
+; Print function
+; %r0 <- Ptr to Null terminated string (ASCIIz)
+; %r1 <- Ptr to text screen buffer
+; %r2 <- Color atributte
+; return nothing
+print:
+        LLS %r2, %r2, 8
+
+print_loop:
+        LOAD.B %r3, %r0         ; Loads in %r3 a character
+        IFEQ %r3, 0             ; If is NULL then ends
+          RJMP print_end
+
+        OR %r3, %r3, %r2        ; Add color attribute
+        STORE.W %r1, %r3
+
+        ADD %r1, %r1, 2         ; Increment pointers and do the loop
+        ADD %r0, %r0, 1
+        RJMP print_loop
+
+print_end:
+        
+        RET
+
+
+; Print HEX byte function
+; %r0 <- Byte to print
+; %r1 <- Ptr to text screen buffer palce to print
+; %r2 <- Color atributte
+; return nothing
+print_hex_b:
+        PUSH %r5
+
+        LLS %r2, %r2, 8
+        LRS %r5, %r0, 4         ; MS nible to %r5
+        AND %r0, %r0, 0x0000000F      ; LS nible to %r0
+
+        ; Print MS nible first
+        ; 0xA + 55 = 'A'
+        ; 0x9 + 55 = 64 -> 64 -7 = 57 = '9'
+        ADD %r5, %r5, 55
+        IFL %r5, 'A'
+          SUB %r5, %r5, 7
+
+        OR %r5, %r5, %r2
+        STORE.W %r1, %r5
+
+        ; Print LS nible first
+        ADD %r1, %r1, 2
+        ADD %r5, %r0, 55
+        IFL %r5, 'A'
+          SUB %r5, %r5, 7
+
+        OR %r5, %r5, %r2
+        STORE.W %r1, %r5
+        
+        POP %r5
+
+        RET
+
+
+; Print HEX word function
+; %r0 <- Word to print
+; %r1 <- Ptr to text screen buffer palce to print
+; %r2 <- Color atributte
+; return nothing
+print_hex_w:
+        PUSH %r5
+
+        LLS %r2, %r2, 8
+        LRS %r5, %r0, 12         ; MS nible to %r5
+
+        ; Print MS nible first
+        ; 0xA + 55 = 'A'
+        ; 0x9 + 55 = 64 -> 64 -7 = 57 = '9'
+        ADD %r5, %r5, 55
+        IFL %r5, 'A'
+          SUB %r5, %r5, 7
+
+        OR %r5, %r5, %r2
+        STORE.W %r1, %r5
+
+        ; Print next nible first
+        LRS %r5, %r0, 8
+        AND %r5, %r5, 0x0F
+
+        ADD %r1, %r1, 2
+        ADD %r5, %r5, 55
+        IFL %r5, 'A'
+          SUB %r5, %r5, 7
+
+        OR %r5, %r5, %r2
+        STORE.W %r1, %r5
+        
+        ; Print next nible first
+        LRS %r5, %r0, 4
+        AND %r5, %r5, 0x0F
+
+        ADD %r1, %r1, 2
+        ADD %r5, %r5, 55
+        IFL %r5, 'A'
+          SUB %r5, %r5, 7
+
+        OR %r5, %r5, %r2
+        STORE.W %r1, %r5
+        
+        ; Print next nible first
+        AND %r5, %r0, 0x0F
+
+        ADD %r1, %r1, 2
+        ADD %r5, %r5, 55
+        IFL %r5, 'A'
+          SUB %r5, %r5, 7
+
+        OR %r5, %r5, %r2
+        STORE.W %r1, %r5
+        
+        POP %r5
+
+        RET
+
+
+; Clear screen. Fills the scren with spaces and a particular color attribute
+; %r0 <- Ptr to text screen buffer
+; %r1 <- Color atributte
+clr_screen:
+        MOV %r3, 2400 ; Ptr to the end of the screen
+        ADD %r3, %r3, %r0
+
+        LLS %r1, %r1, 8
+        OR %r1, %r1, 0x20  ; Prepare fill word
+
+clr_screen_loop:
+        STORE.W %r0, %r1
+        ADD %r0, %r0, 2
+
+        IFLE %r0, %r3
+          RJMP clr_screen_loop
+
+        RET

--- a/test.asm
+++ b/test.asm
@@ -10,38 +10,17 @@ begin:
         MOV %r8, 8 
         MOV %r9, 9 
         MOV %r10, 10 
-        MOV %r11, 11
-        MOV %r12, 12 
-        MOV %r13, 13
-        MOV %r14, 14
-        MOV %r15, 15
-        MOV %r16, 16
-        MOV %r17, 17 
-        MOV %r18, 18 
-        MOV %r19, 19
-        MOV %r20, 20
-        MOV %r21, 21
-        MOV %r22, 22
-        MOV %r23, 23
-        MOV %r24, 24
-        MOV %r25, 25
-        MOV %r26, 26
-        MOV %r27, 27        ; This are special registers!
-        MOV %r30, 30
-        MOV %r31, 31        ; Addr: 07Ch
+        MOV %r11, 11 
         MOV %bp, 0        
         MOV %sp, 0x30000    ; Sets Stack Pointer to the end of the 128KiB RAM     
-        MOV %ia, isr                 
+        MOV %ia, vtable                 
         MOV %flags, 0x100    ; Enable interrupts           
-	MOV %r1, 'E'        ; Test ASCII literals
-	MOV %r1, ' '        ; Test ASCII literals
-	MOV %r1, ','        ; Test ASCII literals
         MOV %r1, 0xBEBECAFE   
         ; Tested seting registers and using bit literal
 
         MOV %r10 , %r1      ; %r10 = 0xBEBECAFE
         SWP %r7, %r9        ; %r9 = 7 ; %r7 = 9
-        NOT %r0, %r0        ; %r0 = 0xFFFFFFFF = -1
+        NOT %r0, %r0        ; %r0 = 0xFFFFFFFE
         XCHGB %r4           ; %r4 = 0x400
         XCHGW %r5           ; %r5 = 0x50000
 
@@ -80,192 +59,240 @@ test_alu:                       ; PC = 0x010C
         ; Testing BOOLEAN instructions
         MOV %r7, 0x5555AAAA
         MOV %r6, 0xAAFFFF55
-        NOT %r12, %r6           ; %r12 = 0x550000AA
-        IFNEQ %r12, 0x550000AA
+        NOT %r11, %r6           ; %r11 = 0x550000AA
+        IFNEQ %r11, 0x550000AA
             JMP crash
 
-        AND %r12, %r7, %r6      ; %r12 = 0x0055AA00
-        IFNEQ %r12, 0x0055AA00
+        AND %r11, %r7, %r6      ; %r11 = 0x0055AA00
+        IFNEQ %r11, 0x0055AA00
             JMP crash
 
-        OR %r12, %r7, %r6       ; %r12 = 0xFFFFFFFF
-        IFNEQ %r12, 0xFFFFFFFF
+        OR %r11, %r7, %r6       ; %r11 = 0xFFFFFFFF
+        IFNEQ %r11, 0xFFFFFFFF
             JMP crash
 
-        XOR %r12, %r7, %r6      ; %r12 = 0xFFAA55FF
-        IFNEQ %r12, 0xFFAA55FF
+        XOR %r11, %r7, %r6      ; %r11 = 0xFFAA55FF
+        IFNEQ %r11, 0xFFAA55FF
             JMP crash
 
-        BITC %r12, %r7, %r6     ; %r12 = 0x550000AA
-        IFNEQ %r12, 0x550000AA
+        BITC %r11, %r7, %r6     ; %r11 = 0x550000AA
+        IFNEQ %r11, 0x550000AA
             JMP crash
 
         ; Testing Addition/Substraction instructions
-        ADD %r12, %r8, %r4      ; %r12 = %r8 + %r4 = 0x408
-        IFNEQ %r12, 0x408
+        ADD %r11, %r8, %r4      ; %r11 = %r8 + %r4 = 0x408
+        IFNEQ %r11, 0x408
             JMP crash
 
         ADD %r0, %r8, 1         ; %r0 = %r8 +1 = 9
         IFNEQ %r0, 9
             JMP crash
         
-        SUB %r22, %r12, %r0     ; %r22 = %r12 - %r0 = 0x3FF
-        IFNEQ %r22, 0x3FF
+        SUB %r10, %r11, %r0     ; %r10 = %r11 - %r0 = 0x3FF
+        IFNEQ %r10, 0x3FF
             JMP crash
 
-        SUB %r22, %r24, 4       ; %r22 = %r24 -4 = 20 = 0x14
-        IFNEQ %r22, 20
-            JMP crash
+        ;SUB %r22, %r24, 4       ; %r22 = %r24 -4 = 20 = 0x14
+        ;IFNEQ %r22, 20
+        ;    JMP crash
 
-        SUB %r22, %r24, -4      ; %r22 = %r24 -(-4) = 28 = 0x1C
-        IFNEQ %r22, 28
-            JMP crash
+        ;SUB %r22, %r24, -4      ; %r22 = %r24 -(-4) = 28 = 0x1C
+        ;IFNEQ %r22, 28
+        ;    JMP crash
 
-        RSB %r22, %r24, -4      ; %r22 = -4 - %r24 = -28 = 0xFFFFFFE4
-        IFNEQ %r22, -28
-            JMP crash
+        ;RSB %r22, %r24, -4      ; %r22 = -4 - %r24 = -28 = 0xFFFFFFE4
+        ;IFNEQ %r22, -28
+        ;    JMP crash
 
         ; Testing Overflow
-        MOV %r22, 0x40000000
-        MOV %r23, 0x60000000
-        ADD %r24, %r22, %r23    ; %r24 = 0x40000000 + 0x60000000 = 0xA0000000 (negative)
+        MOV %r9, 0x40000000
+        MOV %r10, 0x60000000
+        ADD %r11, %r10, %r9    ; %r11 = 0x40000000 + 0x60000000 = 0xA0000000 (negative)
         IFCLEAR %flags, 2       ; If OF == 0 -> Jump to crash
             JMP crash
         ; TODO Overflow with substraction
 
         ; Testing Carry doing 64 bit addition and substraction
-        MOV %r20, 0xFFFFFFFF    ; LSB op1
-        MOV %r21, 0x00000001    ; MSB op1
-        MOV %r22, 0x00000001    ; LSB op2
-        MOV %r23, 0x00000100    ; MSB op2
+        MOV %r8,  0xFFFFFFFF    ; LSB op1
+        MOV %r9,  0x00000001    ; MSB op1
+        MOV %r10, 0x00000001    ; LSB op2
+        MOV %r11, 0x00000100    ; MSB op2
         ; Result of addtion must be 0x00000102_00000000
-        ADD %r24, %r20, %r22    ; Adds LSB
-        ADDC %r25, %r21, %r23   ; Adds MSB
-        IFNEQ %r24, 0
+        ADD %r6, %r8, %r10    ; Adds LSB
+        ADDC %r7, %r9, %r11   ; Adds MSB
+        IFNEQ %r6, 0
             JMP crash
-        IFNEQ %r25, 0x102
+        IFNEQ %r7, 0x102
             JMP crash
         
         ; Result of addtion must be 0xFFFFFF01_FFFFFFFE
-        SUB %r24, %r20, %r22    ; Subs LSB
-        SUBB %r25, %r21, %r23   ; Subs MSB
-        IFNEQ %r24, 0xFFFFFFFE
-            JMP crash
-        IFNEQ %r25, 0xFFFFFF01
-            JMP crash
+ ;       SUB %r24, %r20, %r22    ; Subs LSB
+ ;       SUBB %r25, %r21, %r23   ; Subs MSB
+ ;       IFNEQ %r24, 0xFFFFFFFE
+ ;           JMP crash
+ ;       IFNEQ %r25, 0xFFFFFF01
+ ;           JMP crash
 
         ; Testing Shift instructions
         ; %r6 = 0xAAFFFF55
-        LLS %r12, %r6, 8        ; %r12 = 0xFFFF5500
-        IFNEQ %r12, 0xFFFF5500
+        ; %r7 = 0x55FFFFAA
+				MOV %r6, 0xAAFFFF55
+				MOV %r7, 0x55FFFFAA
+        LLS %r10, %r6, 8        ; %r10 = 0xFFFF5500
+        IFNEQ %r10, 0xFFFF5500
             JMP crash
 
-        LRS %r12, %r6, 8        ; %r12 = 0x00AAFFFF
-        IFNEQ %r12, 0x00AAFFFF
+        LRS %r10, %r6, 8        ; %r10 = 0x00AAFFFF
+        IFNEQ %r10, 0x00AAFFFF
             JMP crash
         
-        ARS %r12, %r6, 8        ; %r12 = 0xFFAAFFFF
-        IFNEQ %r12, 0xFFAAFFFF
+        ARS %r10, %r6, 8        ; %r10 = 0xFFAAFFFF
+        IFNEQ %r10, 0xFFAAFFFF
             JMP crash
-        ARS %r12, %r7, 8        ; %r12 = 0x005555AA
-        IFNEQ %r12, 0x005555AA
-            JMP crash
-
-        ROTL %r12, %r6, 8       ; %r12 = 0xFFFF55AA
-        IFNEQ %r12, 0xFFFF55AA
+        ARS %r10, %r7, 8        ; %r10 = 0x0055FFFF
+        IFNEQ %r10, 0x0055FFFF
             JMP crash
 
-        ROTR %r12, %r6, 8       ; %r12 = 0x55AAFFFF
-        IFNEQ %r12, 0x55AAFFFF
+        ROTL %r10, %r6, 8       ; %r10 = 0xFFFF55AA
+        IFNEQ %r10, 0xFFFF55AA
+            JMP crash
+
+        ROTR %r10, %r6, 8       ; %r10 = 0x55AAFFFF
+        IFNEQ %r10, 0x55AAFFFF
             JMP crash
 
         ; Testing Multiplication/Division
-        MOV %r22, 100
-        MOV %r23, 4000000001
-        MUL %r24, %r23, %r22     ; %y:%r24 = 400000000100
-        IFNEQ %r24, 0x21DBA064
+        MOV %r8, 100
+        MOV %r9, 4000000001
+        MUL %r10, %r9, %r8     ; %y:%r10 = 400000000100
+        IFNEQ %r10, 0x21DBA064
             JMP crash
         IFNEQ %y, 0x5D
             JMP crash
 
-        DIV %r24, %r23, %r22     ; %r24 = 40000000 ; %y = 1
-        IFNEQ %r24, 0x02625A00
+        DIV %r10, %r9, %r8     ; %r10 = 40000000 ; %y = 1
+        IFNEQ %r10, 0x02625A00
             JMP crash
         IFNEQ %y, 1
             JMP crash
+
+        ; Try LOAD and STORE
+        ;MOV %r10, countervar
+        ;STORE.W %r10, 0xBEBA
+        ;LOAD.W %r0, %r10
+        ;IFNEQ %r0, 0xBEBA
+        ;    JMP crash
+
         ; TODO Signed Multiplication/Division
         ; TODO Check Division error flag
 
-        ; TODO Check LOAD/STORE
-        ; TODO Check Stack instrucctions
-        ; TODO Check CALL functions
         ; TODO Check other instrucctions
 
-        CALL print_ok
+; Setup the Vector Table
+        MOV %r0, int_A0
+        MOV %r1, vtable
+        ADD %r1, %r1, 0x280 ; 0xA0 * 4
+        STORE %r1, %r0
 
+; Basic checks finished, inform about it
+
+        MOV %r0, 0xFF0A0000
+        MOV %r1, 0x07           ; Clear the screen with black border and light gray ink
+        CALL clr_screen
+
+        MOV %r0, str_basic_tests
+        MOV %r1, 0xFF0A0000
+        MOV %r2, 0x07
+        CALL print
+
+        MOV %r0, str_ok
+        MOV %r1, 0xFF0A0016
+        MOV %r2, 0x0A
+        RCALL print
+
+        ; Print RAM size
+        MOV %r1, 0
+        INT A0h
+        LRS %r0, %r1, 10
+        MOV %r1, 0xFF0A00A0         
+        MOV %r2, 0x0F
+        CALL print_hex_w
         
-        LOAD.B %r3, 0x10000     ; Load countervar
-        ADD %r0, %r3, 0x30      ; + '0'
-        MOV %r1, 0x0100         ; Column 0, Row 1
-        MOV %r2, 0x70           ; Light gray paper, black Ink
-        CALL print_chr
+        MOV %r0, str_kib
+        MOV %r1, 0xFF0A00AA
+        MOV %r2, 0x0F
+        RCALL print
+
+
+        MOV %r10, countervar
+for_ever_loop:        
+        LOAD.W %r0, %r10        ; Load countervar
+        ADD %r1, %r0, 0x1
+        STORE.W %r10, %r1
+
+        MOV %r1, 0xFF0A0050         
+        MOV %r2, 0x0E
+        CALL print_hex_w
         
-        ;INT 0x9
         
-        JMP begin               ; Begin again in a endless loop
+        RJMP for_ever_loop
+
 crash:
+        ; Try to print that the test fails (probably will not do it)
+        MOV %r0, 0xFF0A0000
+        MOV %r1, 0x07           ; Clear the screen with black border and light gray ink
+        CALL clr_screen
+
+        MOV %r0, str_basic_tests
+        MOV %r1, 0xFF0A0000
+        MOV %r2, 0x07
+        CALL print
+
+        MOV %r0, str_fail
+        MOV %r1, 0xFF0A0016
+        MOV %r2, 0x0C
+        CALL print
+
         SLEEP               ; Sleeps because something goes wrong
 
 
 ; *****************************************************************************
-print_ok:                   ; Prints OK in CDA text mode 0
-       MOV %r0, 0x80
-       STORE.B 0xFF0ACC00, %r0 ; Text mode 0, default font and palette, no vsync
-       
-       MOV %r0, 0x706B724F
-       STORE 0xFF0A0000, %r0   ; Writes Ok in VRRAM
+; Try to measure RAM in multiples of 128 KiB and return it in %r1
+int_A0:
+      PUSH %r2
+      PUSH %flags
 
-       RET
+      MOV %r1, 0x10000
+loop_int_A0:
+      ADD %r1, %r1, 0x20000
+      MOV %r2, 0xAA55
+      STORE.W %r1, %r2
+      LOAD.W %r0, %r1
+      IFEQ %r0, 0xAA55    ; We can read/write at that address so is RAM
+        RJMP loop_int_A0
 
+      SUB %r1, %r1, 0x10000   ; Now %r1 have the size of the RAM minus the ROM size
 
-; Prints a %r0 digit in screen 0 with textmode 0, at column %r1[0:7], row %r1[8:15]
-;       attribute  %r2
-; Asummes that row < 30 and column < 40
-print_chr:
-      PUSH %r4
-      PUSH %r5
-      AND %r4, %r1, 0x3F          ; Grabs column and puts in %r4
-      LRS %r5, %r1, 8             ; Grabs row and puts in %r5
-      MUL %r5, %r5, 0x28
-      ADD %r4, %r4, %r5           ; %r4 = row*40 + column
-      LLS %r4, %r4, 1             ; %r4 *= 2
-      ADD %r4, %r4 ,0xFF0A0000
-      STORE.B %r4, %r0            ; Write character
-      ADD %r4, %r4, 1
-      STORE.B %r4, %r2            ; Write Attribute
-
-      POP %r5
-      POP %r4
-
-      RET
-
-; *****************************************************************************
-isr:
-     
-      PUSH %r3
-      PUSH %r4
-
-      LOAD.B %r3, 0x10000     ; Load countervar
-      
-      ADD %r3, %r3, 1
-      DIV %r4, %r3, 10
-      MOV %r3, %y             ; %r3 = %r3 % 10
-
-      STORE.B 0x10000, %r3    ; Stores counter new value TODO Fails
-      
-      POP %r4
-      POP %r3
+      POP %flags
+      POP %r2
 
       RFI
+      
+      
 
-      .DAT 21h, 22h, '\'', '\"', 'a', '\t', '\r', '\n', '\0', ' ', "T" 
+; *****************************************************************************
+      .include "lib.inc"
+
+; Strings
+str_ok:               .DB "OK",0
+str_fail:             .DB "FAIL",0
+
+str_kib:              .DB "KiB of RAM",0
+
+str_basic_tests:      .DB "BASIC TEST",0
+
+
+                      .ORG 0x10000
+countervar:           .DD 0
+; Vector table
+vtable:               

--- a/tr3200.isf
+++ b/tr3200.isf
@@ -1,7 +1,7 @@
 # Comment
 <HEAD>
 ISN:"TR3200"
-ISD:"TR3200 CPU Instruction set from doc 0.7"
+ISD:"TR3200 CPU Instruction set from doc 0.9"
 # endian-ness LE (little endian), BE (big endian), NE (endianless i.e. PY
 CPUE:LE
 # memory word size
@@ -33,27 +33,11 @@ ALIGN:4
 %r8,%R8:%01000
 %r9,%R9:%01001
 %r10,%R10:%01010
-%r11,%R11:%01011
-%r12,%R12:%01100
-%r13,%R13:%01101
-%r14,%R14:%01110
-%r15,%R15:%01111
-%r16,%R16:%10000
-%r17,%R17:%10001
-%r18,%R18:%10010
-%r19,%R19:%10011
-%r20,%R20:%10100
-%r21,%R21:%10101
-%r22,%R22:%10110
-%r23,%R23:%10111
-%r24,%R24:%11000
-%r25,%R25:%11001
-%r26,%R26:%11010
-%r27,%R27,%y,%Y:%11011
-%r28,%R28,%ia,%IA:%11100
-%r29,%R29,%flags,%FLAGS:%11101
-%r30,%R30,%bp,%BP:%11110
-%r31,%R31,%sp,%SP:%11111
+%r11,%R11,%y,%Y:%01011
+%r12,%R12,%bp,%BP:%01100
+%r13,%R13,%sp,%SP:%01101
+%r14,%R14,%ia,%IA:%01110
+%r15,%R15,%flags,%FLAGS:%01111
 # attrib set Special 32 bit, encode Length 5 bits
 # Special reserves the names, they may or may not have encodings
 +S32,L5


### PR DESCRIPTION
The last changes to the specs, **reduces the register set to 16**, but keeps intact the instruction format.
This updates the **isf** file to these changes, plus gets the latest _test.asm_ program that uses #include to grab a small library of utility functions.
